### PR TITLE
Migrate to the new base image

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,5 @@
 # Use a minimal base image
-FROM slough-dev-dc-generic-base:0.0.1 AS base
+FROM slough-dev-dc-generic-base:0.0.3 AS base
 
 # Install `uv`
 RUN wget https://astral.sh/uv/install.sh
@@ -7,11 +7,11 @@ RUN chmod +x install.sh
 RUN ./install.sh
 RUN rm install.sh
 
-# Install Python
-# Normally, we would install Python using `uv`, but `uv` doesn't provide images
-# for Alpine (yet). Maybe later, it will.
-# https://github.com/astral-sh/uv/issues/6392
-RUN sudo apk add --no-cache python3=3.12.6-r0
+# Generate shell completion for uv
+RUN echo 'eval "$(/home/developer/.cargo/bin/uv generate-shell-completion bash)"' >> .bashrc.local
+
+# Install a few Python versions
+RUN /home/developer/.cargo/bin/uv python install 3.12
 
 # Configure Starship
 ENV PROMPTNAME="PYTHON"


### PR DESCRIPTION
This base image is based of a Debian base image instead of Alpine, so I had to update the commands to install Python as well. This means that we can use `uv` now to install Python, which gives us the ability to install a specific version of Python.

Fixes #6